### PR TITLE
Added WithErrorCallback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,31 @@
 `walker` is a faster, parallel version, of `filepath.Walk`.
 
 ```
-walker.Walk("/tmp", func(pathname string, fi os.FileInfo) error {
+// walk function called for every path found
+walkFn := func(pathname string, fi os.FileInfo) error {
     fmt.Printf("%s: %d bytes\n", pathname, fi.Size())
+    return nil
+}
+
+// error function called for every error encountered
+errorCallbackOption := walker.WithErrorCallback(func(pathname string, err error) error {
+    // ignore permissione errors
+    if os.IsPermission(err) {
+        return nil
+    }
+    // halt traversal on any other error
+    return err
 })
+
+walker.Walk("/tmp", walkFn, errorCallbackOption)
 ```
 
 ## Benchmarks
 
 - Standard library (`filepath.Walk`) is `FilepathWalk`.
 - This library is `WalkerWalk`
-- `FastwalkWalk` is [https://github.com/golang/tools/tree/master/internal/fastwalk](fastwalk).
-- `GodirwalkWalk` is [https://github.com/karrick/godirwalk](godirwalk).
+- `FastwalkWalk` is [fastwalk](https://github.com/golang/tools/tree/master/internal/fastwalk).
+- `GodirwalkWalk` is [godirwalk](https://github.com/karrick/godirwalk).
 
 This library and `filepath.Walk` both perform `os.Lstat` calls and provide a full `os.FileInfo` structure to the callback. `BenchmarkFastwalkWalkLstat` and `BenchmarkGodirwalkWalkLstat` include this stat call for better comparison with `BenchmarkFilepathWalk` and `BenchmarkWalkerWalk`.
 

--- a/walker_option.go
+++ b/walker_option.go
@@ -1,0 +1,18 @@
+package walker
+
+// WalkerOption is an option to configure Walk() behaviour.
+type WalkerOption func(*walkerOptions) error
+
+type walkerOptions struct {
+	errorCallback func(pathname string, err error) error
+}
+
+// WithErrorCallback sets a callback to be used for error handling. Any error
+// returned will halt the Walk function and return the error. If the callback
+// returns nil Walk will continue.
+func WithErrorCallback(callback func(pathname string, err error) error) WalkerOption {
+	return func(o *walkerOptions) error {
+		o.errorCallback = callback
+		return nil
+	}
+}


### PR DESCRIPTION
Walk() can now accept options to configure behaviour. WithErrorCallback sets a
function to be called whenever an error is encountered, allowing the error to
passthrough or a nil to be returned for filesystem traversal to continue.

```
// walk function called for every path found
walkFn := func(pathname string, fi os.FileInfo) error {
    fmt.Printf("%s: %d bytes\n", pathname, fi.Size())
    return nil
}

// error function called for every error encountered
errorCallbackOption := walker.WithErrorCallback(func(pathname string, err error) error {
    // ignore permissione errors
    if os.IsPermission(err) {
        return nil
    }
    // halt traversal on any other error
    return err
})

walker.Walk("/tmp", walkFn, errorCallbackOption)
```

Fixes #1 