### PR TITLE
fix "interrupted system call" error

### DIFF
--- a/walker_unix.go
+++ b/walker_unix.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (w *walker) readdir(dirname string) error {
-	fd, err := syscall.Open(dirname, 0, 0)
+	fd, err := open(dirname, 0, 0)
 	if err != nil {
 		return &os.PathError{Op: "open", Path: dirname, Err: err}
 	}
@@ -23,7 +23,7 @@ func (w *walker) readdir(dirname string) error {
 	for {
 		if bufp >= nbuf {
 			bufp = 0
-			nbuf, err = syscall.ReadDirent(fd, buf)
+			nbuf, err = readDirent(fd, buf)
 			if err != nil {
 				return err
 			}
@@ -48,5 +48,40 @@ func (w *walker) readdir(dirname string) error {
 			}
 		}
 	}
-	return nil
+	// never reach
+}
+
+// According to https://golang.org/doc/go1.14#runtime
+// A consequence of the implementation of preemption is that on Unix systems, including Linux and macOS
+// systems, programs built with Go 1.14 will receive more signals than programs built with earlier releases.
+//
+// This causes syscall.Open and syscall.ReadDirent sometimes fail with EINTR errors.
+// We need to retry in this case.
+type temporaryError interface {
+	error
+	Temporary() bool
+}
+
+func open(path string, mode int, perm uint32) (fd int, err error) {
+	for {
+		nbuf, err := syscall.Open(path, mode, perm)
+		if err == nil {
+			return nbuf, nil
+		}
+		if err, ok := err.(temporaryError); !ok || !err.Temporary() {
+			return 0, err
+		}
+	}
+}
+
+func readDirent(fd int, buf []byte) (n int, err error) {
+	for {
+		nbuf, err := syscall.ReadDirent(fd, buf)
+		if err == nil {
+			return nbuf, nil
+		}
+		if err, ok := err.(temporaryError); !ok || !err.Temporary() {
+			return 0, err
+		}
+	}
 }

--- a/walker_unix.go
+++ b/walker_unix.go
@@ -64,9 +64,9 @@ type temporaryError interface {
 
 func open(path string, mode int, perm uint32) (fd int, err error) {
 	for {
-		nbuf, err := syscall.Open(path, mode, perm)
+		fd, err := syscall.Open(path, mode, perm)
 		if err == nil {
-			return nbuf, nil
+			return fd, nil
 		}
 		if err, ok := err.(temporaryError); !ok || !err.Temporary() {
 			return 0, err


### PR DESCRIPTION
I sometimes got "interrupted system call" error.
This pull request will fix it.

```
$ go test -v -bench ^BenchmarkWalkerWalk -run none
goos: darwin
goarch: amd64
pkg: github.com/saracen/walker
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkWalkerWalk
    walker_test.go:187: interrupted system call
--- FAIL: BenchmarkWalkerWalk-8
BenchmarkWalkerWalkAppend
    walker_test.go:200: interrupted system call
--- FAIL: BenchmarkWalkerWalkAppend-8
FAIL
exit status 1
FAIL    github.com/saracen/walker       2.155s
```

```
$ go test -v -bench ^BenchmarkWalkerWalk -run none -benchtime 1m
goos: darwin
goarch: amd64
pkg: github.com/saracen/walker
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkWalkerWalk
    walker_test.go:187: open /usr/local/go/src/crypto/ed25519/internal/edwards25519: interrupted system call
--- FAIL: BenchmarkWalkerWalk-8
BenchmarkWalkerWalkAppend
    walker_test.go:200: open /usr/local/go/src/cmd/vendor/golang.org/x/tools/internal/analysisinternal: interrupted system call
--- FAIL: BenchmarkWalkerWalkAppend-8
FAIL
exit status 1
FAIL    github.com/saracen/walker       8.928s
```

According to https://golang.org/doc/go1.14#runtime
A consequence of the implementation of preemption is that on Unix systems, including Linux and macOS
systems, programs built with Go 1.14 will receive more signals than programs built with earlier releases.

This causes `syscall.Open` and `syscall.ReadDirent` sometimes fail with EINTR errors.
We need to retry in this case.
