### PR TITLE
sync the fastwalk package with upstream

### DIFF
--- a/testdata/fastwalk/fastwalk.go
+++ b/testdata/fastwalk/fastwalk.go
@@ -14,14 +14,14 @@ import (
 	"sync"
 )
 
-// TraverseLink is used as a return value from WalkFuncs to indicate that the
+// ErrTraverseLink is used as a return value from WalkFuncs to indicate that the
 // symlink named in the call may be traversed.
-var TraverseLink = errors.New("fastwalk: traverse symlink, assuming target is a directory")
+var ErrTraverseLink = errors.New("fastwalk: traverse symlink, assuming target is a directory")
 
-// SkipFiles is a used as a return value from WalkFuncs to indicate that the
+// ErrSkipFiles is a used as a return value from WalkFuncs to indicate that the
 // callback should not be called for any other files in the current directory.
 // Child directories will still be traversed.
-var SkipFiles = errors.New("fastwalk: skip remaining files in directory")
+var ErrSkipFiles = errors.New("fastwalk: skip remaining files in directory")
 
 // Walk is a faster implementation of filepath.Walk.
 //
@@ -167,7 +167,7 @@ func (w *walker) onDirEnt(dirName, baseName string, typ os.FileMode) error {
 
 	err := w.fn(joined, typ)
 	if typ == os.ModeSymlink {
-		if err == TraverseLink {
+		if err == ErrTraverseLink {
 			// Set callbackDone so we don't call it twice for both the
 			// symlink-as-symlink and the symlink-as-directory later:
 			w.enqueue(walkItem{dir: joined, callbackDone: true})

--- a/testdata/fastwalk/fastwalk_dirent_fileno.go
+++ b/testdata/fastwalk/fastwalk_dirent_fileno.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build freebsd || openbsd || netbsd
 // +build freebsd openbsd netbsd
 
 package fastwalk

--- a/testdata/fastwalk/fastwalk_dirent_ino.go
+++ b/testdata/fastwalk/fastwalk_dirent_ino.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (linux || darwin) && !appengine
 // +build linux darwin
 // +build !appengine
 

--- a/testdata/fastwalk/fastwalk_dirent_namlen_bsd.go
+++ b/testdata/fastwalk/fastwalk_dirent_namlen_bsd.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin || freebsd || openbsd || netbsd
 // +build darwin freebsd openbsd netbsd
 
 package fastwalk

--- a/testdata/fastwalk/fastwalk_dirent_namlen_linux.go
+++ b/testdata/fastwalk/fastwalk_dirent_namlen_linux.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux
-// +build !appengine
+//go:build linux && !appengine
+// +build linux,!appengine
 
 package fastwalk
 

--- a/testdata/fastwalk/fastwalk_portable.go
+++ b/testdata/fastwalk/fastwalk_portable.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build appengine || (!linux && !darwin && !freebsd && !openbsd && !netbsd)
 // +build appengine !linux,!darwin,!freebsd,!openbsd,!netbsd
 
 package fastwalk
@@ -26,7 +27,7 @@ func readDir(dirName string, fn func(dirName, entName string, typ os.FileMode) e
 			continue
 		}
 		if err := fn(dirName, fi.Name(), fi.Mode()&os.ModeType); err != nil {
-			if err == SkipFiles {
+			if err == ErrSkipFiles {
 				skipFiles = true
 				continue
 			}

--- a/testdata/fastwalk/fastwalk_test.go
+++ b/testdata/fastwalk/fastwalk_test.go
@@ -40,6 +40,8 @@ func testFastWalk(t *testing.T, files map[string]string, callback func(path stri
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tempdir)
+
+	symlinks := map[string]string{}
 	for path, contents := range files {
 		file := filepath.Join(tempdir, "/src", path)
 		if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
@@ -47,7 +49,7 @@ func testFastWalk(t *testing.T, files map[string]string, callback func(path stri
 		}
 		var err error
 		if strings.HasPrefix(contents, "LINK:") {
-			err = os.Symlink(strings.TrimPrefix(contents, "LINK:"), file)
+			symlinks[file] = filepath.FromSlash(strings.TrimPrefix(contents, "LINK:"))
 		} else {
 			err = ioutil.WriteFile(file, []byte(contents), 0644)
 		}
@@ -55,21 +57,38 @@ func testFastWalk(t *testing.T, files map[string]string, callback func(path stri
 			t.Fatal(err)
 		}
 	}
+
+	// Create symlinks after all other files. Otherwise, directory symlinks on
+	// Windows are unusable (see https://golang.org/issue/39183).
+	for file, dst := range symlinks {
+		err = os.Symlink(dst, file)
+		if err != nil {
+			if writeErr := ioutil.WriteFile(file, []byte(dst), 0644); writeErr == nil {
+				// Couldn't create symlink, but could write the file.
+				// Probably this filesystem doesn't support symlinks.
+				// (Perhaps we are on an older Windows and not running as administrator.)
+				t.Skipf("skipping because symlinks appear to be unsupported: %v", err)
+			}
+		}
+	}
+
 	got := map[string]os.FileMode{}
 	var mu sync.Mutex
-	if err := fastwalk.Walk(tempdir, func(path string, typ os.FileMode) error {
+	err = fastwalk.Walk(tempdir, func(path string, typ os.FileMode) error {
 		mu.Lock()
 		defer mu.Unlock()
 		if !strings.HasPrefix(path, tempdir) {
-			t.Fatalf("bogus prefix on %q, expect %q", path, tempdir)
+			t.Errorf("bogus prefix on %q, expect %q", path, tempdir)
 		}
 		key := filepath.ToSlash(strings.TrimPrefix(path, tempdir))
 		if old, dup := got[key]; dup {
-			t.Fatalf("callback called twice for key %q: %v -> %v", key, old, typ)
+			t.Errorf("callback called twice for key %q: %v -> %v", key, old, typ)
 		}
 		got[key] = typ
 		return callback(path, typ)
-	}); err != nil {
+	})
+
+	if err != nil {
 		t.Fatalf("callback returned: %v", err)
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -116,26 +135,25 @@ func TestFastWalk_LongFileName(t *testing.T) {
 }
 
 func TestFastWalk_Symlink(t *testing.T) {
-	switch runtime.GOOS {
-	case "windows", "plan9":
-		t.Skipf("skipping on %s", runtime.GOOS)
-	}
 	testFastWalk(t, map[string]string{
-		"foo/foo.go": "one",
-		"bar/bar.go": "LINK:../foo.go",
-		"symdir":     "LINK:foo",
+		"foo/foo.go":       "one",
+		"bar/bar.go":       "LINK:../foo/foo.go",
+		"symdir":           "LINK:foo",
+		"broken/broken.go": "LINK:../nonexistent",
 	},
 		func(path string, typ os.FileMode) error {
 			return nil
 		},
 		map[string]os.FileMode{
-			"":                os.ModeDir,
-			"/src":            os.ModeDir,
-			"/src/bar":        os.ModeDir,
-			"/src/bar/bar.go": os.ModeSymlink,
-			"/src/foo":        os.ModeDir,
-			"/src/foo/foo.go": 0,
-			"/src/symdir":     os.ModeSymlink,
+			"":                      os.ModeDir,
+			"/src":                  os.ModeDir,
+			"/src/bar":              os.ModeDir,
+			"/src/bar/bar.go":       os.ModeSymlink,
+			"/src/foo":              os.ModeDir,
+			"/src/foo/foo.go":       0,
+			"/src/symdir":           os.ModeSymlink,
+			"/src/broken":           os.ModeDir,
+			"/src/broken/broken.go": os.ModeSymlink,
 		})
 }
 
@@ -184,7 +202,7 @@ func TestFastWalk_SkipFiles(t *testing.T) {
 				mu.Lock()
 				defer mu.Unlock()
 				want["/src/"+filepath.Base(path)] = 0
-				return fastwalk.SkipFiles
+				return fastwalk.ErrSkipFiles
 			}
 			return nil
 		},
@@ -195,11 +213,6 @@ func TestFastWalk_SkipFiles(t *testing.T) {
 }
 
 func TestFastWalk_TraverseSymlink(t *testing.T) {
-	switch runtime.GOOS {
-	case "windows", "plan9":
-		t.Skipf("skipping on %s", runtime.GOOS)
-	}
-
 	testFastWalk(t, map[string]string{
 		"foo/foo.go":   "one",
 		"bar/bar.go":   "two",
@@ -208,7 +221,7 @@ func TestFastWalk_TraverseSymlink(t *testing.T) {
 	},
 		func(path string, typ os.FileMode) error {
 			if typ == os.ModeSymlink {
-				return fastwalk.TraverseLink
+				return fastwalk.ErrTraverseLink
 			}
 			return nil
 		},

--- a/testdata/fastwalk/fastwalk_unix.go
+++ b/testdata/fastwalk/fastwalk_unix.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (linux || darwin || freebsd || openbsd || netbsd) && !appengine
 // +build linux darwin freebsd openbsd netbsd
 // +build !appengine
 
@@ -21,7 +22,7 @@ const blockSize = 8 << 10
 const unknownFileMode os.FileMode = os.ModeNamedPipe | os.ModeSocket | os.ModeDevice
 
 func readDir(dirName string, fn func(dirName, entName string, typ os.FileMode) error) error {
-	fd, err := syscall.Open(dirName, 0, 0)
+	fd, err := open(dirName, 0, 0)
 	if err != nil {
 		return &os.PathError{Op: "open", Path: dirName, Err: err}
 	}
@@ -35,7 +36,7 @@ func readDir(dirName string, fn func(dirName, entName string, typ os.FileMode) e
 	for {
 		if bufp >= nbuf {
 			bufp = 0
-			nbuf, err = syscall.ReadDirent(fd, buf)
+			nbuf, err = readDirent(fd, buf)
 			if err != nil {
 				return os.NewSyscallError("readdirent", err)
 			}
@@ -66,7 +67,7 @@ func readDir(dirName string, fn func(dirName, entName string, typ os.FileMode) e
 			continue
 		}
 		if err := fn(dirName, name, typ); err != nil {
-			if err == SkipFiles {
+			if err == ErrSkipFiles {
 				skipFiles = true
 				continue
 			}
@@ -76,8 +77,9 @@ func readDir(dirName string, fn func(dirName, entName string, typ os.FileMode) e
 }
 
 func parseDirEnt(buf []byte) (consumed int, name string, typ os.FileMode) {
-	// golang.org/issue/15653
-	dirent := (*syscall.Dirent)(unsafe.Pointer(&buf[0]))
+	// golang.org/issue/37269
+	dirent := &syscall.Dirent{}
+	copy((*[unsafe.Sizeof(syscall.Dirent{})]byte)(unsafe.Pointer(dirent))[:], buf)
 	if v := unsafe.Offsetof(dirent.Reclen) + unsafe.Sizeof(dirent.Reclen); uintptr(len(buf)) < v {
 		panic(fmt.Sprintf("buf size of %d smaller than dirent header size %d", len(buf), v))
 	}
@@ -124,4 +126,28 @@ func parseDirEnt(buf []byte) (consumed int, name string, typ os.FileMode) {
 		name = string(nameBuf[:nameLen])
 	}
 	return
+}
+
+// According to https://golang.org/doc/go1.14#runtime
+// A consequence of the implementation of preemption is that on Unix systems, including Linux and macOS
+// systems, programs built with Go 1.14 will receive more signals than programs built with earlier releases.
+//
+// This causes syscall.Open and syscall.ReadDirent sometimes fail with EINTR errors.
+// We need to retry in this case.
+func open(path string, mode int, perm uint32) (fd int, err error) {
+	for {
+		fd, err := syscall.Open(path, mode, perm)
+		if err != syscall.EINTR {
+			return fd, err
+		}
+	}
+}
+
+func readDirent(fd int, buf []byte) (n int, err error) {
+	for {
+		nbuf, err := syscall.ReadDirent(fd, buf)
+		if err != syscall.EINTR {
+			return nbuf, err
+		}
+	}
 }


### PR DESCRIPTION
The main purpose is to fixes https://github.com/golang/go/issues/44478

from latest commit: https://github.com/golang/tools/commit/0150491f5f0a1af95c6e9215e405c6200090bbeb
the tree is https://github.com/golang/tools/tree/0150491f5f0a1af95c6e9215e405c6200090bbeb/internal/fastwalk

The walker package has same issue, and https://github.com/saracen/walker/pull/5 will fix it.
